### PR TITLE
cmek split 5/8: server wiring and app context service lookup

### DIFF
--- a/pkg/common/context/app_context.go
+++ b/pkg/common/context/app_context.go
@@ -63,3 +63,15 @@ func GetService[T any](name string) T {
 	v, _ := GetGlobalContext().serviceMap.Load(name)
 	return v.(T)
 }
+
+// TryGetService attempts to get a service by name.
+// Returns the service and true if found, or zero value and false if not found.
+func TryGetService[T any](name string) (T, bool) {
+	v, ok := GetGlobalContext().serviceMap.Load(name)
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	t, ok := v.(T)
+	return t, ok
+}


### PR DESCRIPTION
Part of splitting pingcap/ticdc#3955 into smaller reviewable PRs.\n\nSplit chain: 5/8. Base branch is split/pr3955-04-encryption-manager.